### PR TITLE
OESE-167 - Test Gutenberg editor in OESE

### DIFF
--- a/modules/modal-parent/modal_parent.php
+++ b/modules/modal-parent/modal_parent.php
@@ -192,14 +192,16 @@ add_action('rest_api_init', function () {
   register_rest_route( 'wpnnmodalparent/v2', 'updatequery', 
     array(
     'methods' => 'GET', 
-    'callback' => 'wpnnmodalparent_updatequery' 
+    'callback' => 'wpnnmodalparent_updatequery',
+    'permission_callback' => '__return_true'
     )
   );
 	
 	register_rest_route( 'wpnnmodalparent/v2', 'getparentbyid', 
     array(
     'methods' => 'GET', 
-    'callback' => 'wpnnmodalparent_getparentbyid_func' 
+    'callback' => 'wpnnmodalparent_getparentbyid_func',
+    'permission_callback' => '__return_true'
     )
   );
 	

--- a/modules/shortcodesblock/shortcodesblock.php
+++ b/modules/shortcodesblock/shortcodesblock.php
@@ -148,12 +148,14 @@ add_action( 'init', 'oese_shortcodes_block_cgb_block_assets' );
 add_action( 'rest_api_init', function () {
 		register_rest_route( 'oeseshortcodeblock/v2', 'optionsquery', array(
           'methods' => 'GET', 
-          'callback' => 'oeseshortcodeblock_options_query' 
+          'callback' => 'oeseshortcodeblock_options_query',
+					'permission_callback' => '__return_true'
     ) );
 		
 		register_rest_route( 'oeseshortcodeblock/v2', 'shortcodequery', array(
           'methods' => 'GET', 
-          'callback' => 'oeseshortcodeblock_shortcode_query' 
+          'callback' => 'oeseshortcodeblock_shortcode_query',
+					'permission_callback' => '__return_true'
     ) );
 });
 


### PR DESCRIPTION
- To isolate the issue, I have to eliminate all errors brought by the recent update to  WP-5.7.2.
- Since WP 5.5,  Calls to "register_rest_route" requires  a 'permission_callback' parameter set to true. otherwise, we get a PHP Notice and this can possibly affect the the json response of other plugins.