### PR TITLE
OESE-Preview and Parent Page Modal Test

### DIFF
--- a/modules/modal-parent/js/modal-parent.js
+++ b/modules/modal-parent/js/modal-parent.js
@@ -73,11 +73,14 @@ function load_parent_modal_html(){
   if (jQuery('.components-base-control.editor-page-attributes__order').length > 0 && jQuery('.wp-nn-parentpage-search-result').length > 0) {
     let cid = jQuery('.wp-nn-parentpage-display-wrapper').attr('cid');
     //var vlu = wp.data.select( 'core/editor' ).getEditedPostAttribute('parent');
-    var vlu = jQuery('.wp-nn-parentpage-rad:checked').attr('value');
+    //var vlu = jQuery('.wp-nn-parentpage-rad:checked').attr('value');
+    var vlu = wp.data.select( 'core/editor' ).getEditedPostAttribute('parent');
     clearInterval(wp_nn_loop_interval);
     //wp.apiFetch({ url: '/wp-json/wpnnmodalparent/v2/getparentbyid?pid='+vlu}).then(data =>{     
       targetElemID = wp.data.select( 'core/editor' ).getEditedPostAttribute('parent');
-      var ttl = jQuery('.wp-nn-parentpage-rad:checked').attr('title');;
+      //var ttl = jQuery('.wp-nn-parentpage-rad:checked').attr('title');
+      var ttl = jQuery('.wp-nn-parentpage-search-result > ul li label.wp-nn-tag-p input[value="'+vlu+'"]').attr('title');
+      jQuery('.wp-nn-parentpage-search-result > ul li label.wp-nn-tag-p input[value="'+vlu+'"]').prop('checked', true);
       ttl = (ttl === undefined || vlu == 0)? '(no parent)': ttl;
       vlu = (vlu === undefined || vlu == 0)? 0: vlu;
       htm = '';
@@ -94,7 +97,7 @@ function load_parent_modal_html(){
   }
 }
 
-jQuery(document).on('click','button[data-label="Document"].edit-post-sidebar__panel-tab',function(e){
+jQuery(document).on('click','button[data-label="Page"].edit-post-sidebar__panel-tab',function(e){
   if(!jQuery('.wp-nn-parentpage-display-wrapper').length){
     wp_nn_loop_interval = setInterval(load_parent_modal_html, 100);
   }
@@ -136,6 +139,24 @@ jQuery(window).bind("load", function() {
       }
     }, 100);
   })
+  
+  
+  var oese_parentmodal_observer_target = document.querySelectorAll(".edit-post-sidebar__panel-tab");
+  for (var i = 0; i < oese_parentmodal_observer_target.length; i++) {
+    create_parentmodal_observer(oese_parentmodal_observer_target[i]);
+  }
+
+  function create_parentmodal_observer(elementToObserve){
+    var create_parentmodal_observer = new MutationObserver(function(mutations) {
+      mutations.forEach(function(mutation){
+        var oese_active_panel = mutation.target.attributes.getNamedItem('data-label').value;
+        if(oese_active_panel == 'Page' && mutation.target.classList.contains('is-active')){ //page is active
+          setTimeout(function(){ load_parent_modal_html() }, 100);
+        } //else block is active
+      })
+    });
+    create_parentmodal_observer.observe(elementToObserve, {attributes: true, childList: false, characterData: false, subtree: false });
+  }
   
   
 });

--- a/modules/oesepreview/admin.js
+++ b/modules/oesepreview/admin.js
@@ -40,10 +40,24 @@ jQuery(window).bind("load", function() {
       columnsettingobserver.observe(mutate_target_element, {childList: true, subtree: false});
       
     }
-  
     
+    var oese_preview_observer_target = document.querySelectorAll(".edit-post-sidebar__panel-tab");
+    for (var i = 0; i < oese_preview_observer_target.length; i++) {
+      create_preview_observer(oese_preview_observer_target[i]);
+    }
+    function create_preview_observer(elementToObserve){
+      var create_preview_observer = new MutationObserver(function(mutations) {
+        mutations.forEach(function(mutation){
+          var oese_active_panel = mutation.target.attributes.getNamedItem('data-label').value;
+          if(oese_active_panel == 'Page' && mutation.target.classList.contains('is-active')){ //page is active
+            setTimeout(function(){ wpnnSetButton() }, 100);
+          } //else block is active
+        })
+      });
+      create_preview_observer.observe(elementToObserve, {attributes: true, childList: false, characterData: false, subtree: false });
+    }
     
-  
+
   }
   
 });


### PR DESCRIPTION
- Fixed issue with parent page modal not rendering when coming from focused to a block then when clicked outside the block which automatically switches the settings page settings. This was caused by the recent attribute change in WordPress sidebar settings tab.
- Fixed issue with parent page changes by simply putting a check on a different page, when it should only change when the select button is clicked.
- Fixed preview warning disappearing when Gutenberg switching to another setting tab panel by focusing to a block then focusing to the page.