### PR TITLE
OESE-198 - preview and parent page modal test

### DIFF
--- a/modules/modal-parent/js/modal-parent.js
+++ b/modules/modal-parent/js/modal-parent.js
@@ -143,22 +143,25 @@ jQuery(window).bind("load", function() {
   
   setTimeout(function(){
     /* create gutenberg settings tab switch observer */
-    var oese_parentmodal_observer_target = document.querySelectorAll(".edit-post-sidebar__panel-tab");
-    for (var i = 0; i < oese_parentmodal_observer_target.length; i++) {
-      create_parentmodal_observer(oese_parentmodal_observer_target[i]);
-    }
+    function create_parentmodal_setting_switch_observer_func(){
+      var oese_parentmodal_observer_target = document.querySelectorAll(".edit-post-sidebar__panel-tab");
+      for (var i = 0; i < oese_parentmodal_observer_target.length; i++) {
+        create_parentmodal_observer(oese_parentmodal_observer_target[i]);
+      }
 
-    function create_parentmodal_observer(elementToObserve){
-      var create_parentmodal_observer = new MutationObserver(function(mutations) {
-        mutations.forEach(function(mutation){
-          var oese_active_panel = mutation.target.attributes.getNamedItem('data-label').value;
-          if(oese_active_panel == 'Page' && mutation.target.classList.contains('is-active')){ //page is active
-            setTimeout(function(){ load_parent_modal_html() }, 500);
-          } //else block is active
-        })
-      });
-      create_parentmodal_observer.observe(elementToObserve, {attributes: true, childList: false, characterData: false, subtree: false });
+      function create_parentmodal_observer(elementToObserve){
+        var create_parentmodal_observer = new MutationObserver(function(mutations) {
+          mutations.forEach(function(mutation){
+            var oese_active_panel = mutation.target.attributes.getNamedItem('data-label').value;
+            if(oese_active_panel == 'Page' && mutation.target.classList.contains('is-active')){ //page is active
+              setTimeout(function(){ load_parent_modal_html() }, 500);
+            } //else block is active
+          })
+        });
+        create_parentmodal_observer.observe(elementToObserve, {attributes: true, childList: false, characterData: false, subtree: false });
+      }
     }
+    create_parentmodal_setting_switch_observer_func();
     
     /* create gutenberg sidebar close/open observer */
     var oese_parentmodal_sidebar_toggle_observer_target = document.querySelectorAll(".interface-interface-skeleton__sidebar");
@@ -170,7 +173,10 @@ jQuery(window).bind("load", function() {
         mutations.forEach(function(mutation){
           mutation.addedNodes.forEach(function(added_node) {
             if(added_node.classList.contains('edit-post-sidebar')) { //sidebar added
-              setTimeout(function(){ load_parent_modal_html() }, 500);
+              setTimeout(function(){ 
+                load_parent_modal_html();
+                create_parentmodal_setting_switch_observer_func();
+              }, 500);
             }
           });
   

--- a/modules/oesepreview/admin.css
+++ b/modules/oesepreview/admin.css
@@ -55,3 +55,41 @@ div#oese-preview-draft-publish-warning {
 .components-panel__row.wpnn-preview {
     display: block !important;
 }
+
+/* Preloader */
+.oese-preview-tmp-preloader .lds-ring {
+    display: inline-block;
+    position: relative;
+    width: 32px;
+    height: 32px;
+    margin-top: 10px;
+}
+.oese-preview-tmp-preloader .lds-ring div {
+    box-sizing: border-box;
+    display: block;
+    position: absolute;
+    width: 32px;
+    height: 32px;
+    margin: 3px;
+    border: 3px solid #505050;
+    border-radius: 50%;
+    animation: lds-ring 1.2s cubic-bezier(0.5, 0, 0.5, 1) infinite;
+    border-color: #007cba transparent transparent transparent;
+}
+.oese-preview-tmp-preloader .lds-ring div:nth-child(1) {
+  animation-delay: -0.45s;
+}
+.oese-preview-tmp-preloader .lds-ring div:nth-child(2) {
+  animation-delay: -0.3s;
+}
+.oese-preview-tmp-preloader .lds-ring div:nth-child(3) {
+  animation-delay: -0.15s;
+}
+@keyframes lds-ring {
+  0% {
+    transform: rotate(0deg);
+  }
+  100% {
+    transform: rotate(360deg);
+  }
+}

--- a/modules/oesepreview/admin.js
+++ b/modules/oesepreview/admin.js
@@ -164,13 +164,11 @@ jQuery(document).on('click','.oese-preview-publish-button',function(e){
 
 // Set Preview HTML/Button/URL Function
 function wpnnSetButton(newstatus,callback){
-    console.log(newstatus);
   if (newstatus === undefined) {
       // newstatus was not passed
       //newstatus = '&new='+wp.data.select( 'core/editor' ).getEditedPostAttribute( 'status' );
       
       setTimeout(function(){
-          console.log('Came Here first');
           jQuery('.edit-post-post-status').append(jQuery(wpnn_preview_element_html));
       },100);
       return;


### PR DESCRIPTION
- Added pre-loader since preview button is loaded through Ajax and can take a few seconds on slow internet.
- Created a function out of the switch observer so it can easily be used in reinstating observers deleted when setting sidebar is closed.
- Minimized Ajax fetch to speed up the loading of preview section.
- Removed console logs