### PR TITLE
OESE-198 - Preview and Parent Page Modal Test (QA Findings)

### DIFF
--- a/modules/oesepreview/admin.css
+++ b/modules/oesepreview/admin.css
@@ -36,6 +36,7 @@ div#oese-preview-draft-publish-warning {
 
 /* GUTENBERG */
 .oese-preview-url-wrapper.gutenberg{
+  display:flex;
   float: none !important;
   padding: 15px 0px 15px 0px !important;
   border-top: 1px solid #e2e4e7 !important;

--- a/modules/oesepreview/admin.js
+++ b/modules/oesepreview/admin.js
@@ -55,7 +55,13 @@ jQuery(window).bind("load", function() {
         }
       
       
-    
+        oese_init_observers();
+        
+      
+      } /*oese_preview_init()*/
+      
+      
+      function oese_init_observers(){
         /* create gutenberg settings tab switch observer */
         function oese_preview_setting_switch_observer(){
           var oese_preview_observer_target = document.querySelectorAll(".edit-post-sidebar__panel-tab");
@@ -69,13 +75,13 @@ jQuery(window).bind("load", function() {
               //mutations.forEach(function(mutation){
                 mutation = mutations[0];
                 var oese_active_panel = mutation.target.attributes.getNamedItem('data-label').value;
-                if((oese_active_panel == 'Page' || oese_active_panel == 'Post')){ //page/post is active
+                //if((oese_active_panel == 'Page' || oese_active_panel == 'Post')){ //page/post is active
                   if(jQuery('.edit-post-post-status').hasClass('is-opened')){
                     if(!jQuery('.oese-preview-url-wrapper').length){
                       setTimeout(function(){ wpnnSetButton() }, 100);
                     }
                   }
-                }
+                //}
               //})
             });
             create_preview_observer.observe(elementToObserve, {attributes: true, childList: false, characterData: false, subtree: false });
@@ -95,10 +101,12 @@ jQuery(window).bind("load", function() {
           			if(added_node.classList.contains('edit-post-sidebar')) { //sidebar added
                   if(jQuery('.edit-post-post-status').hasClass('is-opened')){
                     setTimeout(function(){ 
-                      wpnnSetButton() 
+                      wpnnSetButton();
                       oese_preview_setting_switch_observer();
                     }, 100);
                     
+                  }else{
+                    oese_preview_setting_switch_observer();
                   }
           			}
           		});
@@ -107,8 +115,7 @@ jQuery(window).bind("load", function() {
           });
           create_preview_sidebar_toggle_observer.observe(elementToObserve, {attributes: true, childList: true, characterData: false, subtree: false });
         }
-      
-      } /*oese_preview_init()*/
+      }
 
   }
   
@@ -148,7 +155,7 @@ jQuery(document).on('click','button[data-label="Post"].edit-post-sidebar__panel-
 // Detect focus on title block
 jQuery(document).on('focus','.editor-post-title__input',function(){
   setTimeout(function(){
-    wpnnSetButton(); 
+    //wpnnSetButton(); 
   }, 100);
 })
 

--- a/modules/oesepreview/oesepreviewguten.php
+++ b/modules/oesepreview/oesepreviewguten.php
@@ -711,7 +711,7 @@ function wpnnpreview_element_query(){
     }
   }else{ //Preview Type Of Post
     
-    $_htm .= '<div class="oese-preview-url-wrapper gutenberg" isparent="'.$_isparent.'">';
+    $_htm .= '<div class="components-panel__row oese-preview-url-wrapper gutenberg" isparent="'.$_isparent.'">';
       $_htm .= '<strong><em>Preview URL:</em></strong>';
       $_htm .= '<input id="oese-preview-url-input" type="text" value="'.get_bloginfo('url').'?'.$_getparam.'='.$post->ID.'&preview=true&key='.get_post_meta($post->ID, '_post_oesepreview_pwd', true).'" />';
       $_htm .= '<div class="oese-preview-url-copy button" onclick="oesePreviewDraftCopyToClipboard()">Copy URL</div>';


### PR DESCRIPTION
- Followup fix on disappearing preview button/warning section when closing the settings sidebar.  Sidebar is made out of react wherein when the sidebar is closed, the elements inside it are not just hidden but removed from the DOM, thus breaking JS references to it. Fixed it by re-initializing references.
- Enclosed observers into functions to make them reusable.
- Corrected minor display misalignment.